### PR TITLE
Set default diagnostic script using path.module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ locals {
   resource_group_name        = data.azurerm_resource_group.main.name
   log_analytics_workspace_id = data.azurerm_log_analytics_workspace.main.id
   storage_account_id         = data.azurerm_storage_account.main.id
+  diagnostics_script_path    = var.diagnostics_script_path == "" ? "${path.module}/scripts/diagnostics.sh" : var.diagnostics_script_path
 }
 
 module "azurerm_naming" {
@@ -34,6 +35,6 @@ resource "null_resource" "main" {
     storage_account_id = local.storage_account_id
   }
   provisioner "local-exec" {
-    command = "${var.diagnostics_script_path} ${local.resource_group_name} ${local.log_analytics_workspace_id} ${local.storage_account_id} ${azurerm_databricks_workspace.main.id}"
+    command = "${local.diagnostics_script_path} ${local.resource_group_name} ${local.log_analytics_workspace_id} ${local.storage_account_id} ${azurerm_databricks_workspace.main.id}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "databricks_workspace_sku" {
 variable "diagnostics_script_path" {
   type        = string
   description = "Path to a local script to execute for Databricks diagnostic settings (audit log) setup."
-  default     = "./scripts/diagnostics.sh"
+  default     = ""
 }
 
 variable "module_depends_on" {


### PR DESCRIPTION
Default the diagnostics script path as a local rather than in the variables so we can use the module.path.